### PR TITLE
fix disable during hires fix

### DIFF
--- a/scripts/detail_daemon.py
+++ b/scripts/detail_daemon.py
@@ -225,7 +225,7 @@ class Script(scripts.Script):
             plt.close()
             self.last_vis = fig
             return fig
-        except:
+        except Exception:
             if self.last_vis is not None:
                 return self.last_vis
             return   


### PR DESCRIPTION
`process` it's only executed ONCE per entire job
one job can have multiple `batch counts`

`self.is_hires = False` is in `process`
when hires fix is enable 
`self.is_hires = True` will be set in `before_hr`
if the job end hear then it's fine
but this is not the end when `batch count > 1`

the next batch will not run `batch counts`
since `self.is_hires` nevert reseted to back to `False` for 2nd batch and onwards extension will be disabled

fix is simple
moveing `self.is_hires = False` to `before_process_batch` should solve the issue

---

additional changes apply some formatting

and importantly PEP 8: E722 do not use bare 'except'
> bare 'except' can also catch keyboard interrupt

---

most extension that requires knowing whether or not it's hires pass would would just access the `p.is_hr_pass` attribute and not needing the extra logic, but unfortunately you are working with `denoiser_callback` without easy access to `p`
I think current way is thg is the easiest method